### PR TITLE
fixed the devise.html.erb favicon (tab icon) route

### DIFF
--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -11,6 +11,7 @@
     <%#= javascript_pack_tag 'hello_erb', 'data-turbolinks-track': 'reload' %>
     <%#= javascript_pack_tag 'hello_vue', 'data-turbolinks-track': 'reload' %>
    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
+   <link rel="icon" type="image/png" href="https://res.cloudinary.com/xiway/image/upload/v1619698013/T_logo_g2dfsq.png"/>
   </head>
 
   <body>


### PR DESCRIPTION
devise.html.erb did not have the cloudinary link for favicon (tab icon)